### PR TITLE
Add growable vectors

### DIFF
--- a/haskell-algorithms.cabal
+++ b/haskell-algorithms.cabal
@@ -37,7 +37,9 @@ library
                     , Algorithms.Sorting.Sort3
                     , Algorithms.Sorting.Utility
                     , Algorithms.Utility
-  build-depends:      base ^>=4.15.1.0
+                    , Data.Vector.Growable
+                    , Data.Vector.Growable.Generic
+  build-depends:      base >=4.16.4.0
                     , mtl
                     , random
                     , vector
@@ -61,7 +63,8 @@ test-suite tests
                     , Algorithms.Sorting.Sort3Spec
                     , Algorithms.Sorting.TestUtil
                     , Algorithms.TestUtil
-  build-depends:      base ^>=4.15.1.0
+                    , Data.Vector.GrowableSpec
+  build-depends:      base >=4.16.4.0
                     , QuickCheck
                     , haskell-algorithms
                     , HUnit

--- a/haskell-algorithms.cabal
+++ b/haskell-algorithms.cabal
@@ -70,6 +70,8 @@ test-suite tests
                     , HUnit
                     , hspec
                     , microlens
+                    , mtl
+                    , primitive
                     , vector
 
 benchmark bench

--- a/s/haskell-language-server
+++ b/s/haskell-language-server
@@ -1,3 +1,3 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
-haskell-language-server "$@"
+haskell-language-server-wrapper "$@"

--- a/s/hoogle
+++ b/s/hoogle
@@ -1,3 +1,3 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash ../shell.nix
-hoogle server "$@"
+hoogle server --local "$@"

--- a/src/Data/Vector/Growable.hs
+++ b/src/Data/Vector/Growable.hs
@@ -66,7 +66,8 @@ instance MG.MVector v a => GG.GrowVector (GrowVector v) a where
   basicReserve = growVectorReserve
   basicConserve = growVectorConserve
   basicShrink = growVectorShrink
-  basicMvector = growVectorMvector
+  basicMVector = growVectorMVector
+  basicLength = growVectorLength
   basicCapacity = growVectorCapacity
 
 growVectorNew :: MG.MVector v a => Int -> ST s (GrowVector v s a)
@@ -111,8 +112,8 @@ growVectorShrink (GrowVector ref) maxSize = do
     MG.clear (MG.slice maxSize (capacity' - maxSize) v)
     writeSTRef ref (GrowVectorState v maxSize capacity')
 
-growVectorMvector :: MG.MVector v a => GrowVector v s a -> ST s (v s a)
-growVectorMvector (GrowVector ref) = do
+growVectorMVector :: MG.MVector v a => GrowVector v s a -> ST s (v s a)
+growVectorMVector (GrowVector ref) = do
   (GrowVectorState v size _) <- readSTRef ref
   pure (MG.slice 0 size v)
 
@@ -120,6 +121,11 @@ growVectorCapacity :: GrowVector v s a -> ST s Int
 growVectorCapacity (GrowVector ref) = do
   (GrowVectorState _ _ capacity') <- readSTRef ref
   pure capacity'
+
+growVectorLength :: GrowVector v s a -> ST s Int
+growVectorLength (GrowVector ref) = do
+  (GrowVectorState _ length' _ ) <- readSTRef ref
+  pure length'
 
 -- | Create a new growable vector
 new :: (PrimMonad m, MG.MVector v a) => Int -> m (GrowVector v (PrimState m) a)

--- a/src/Data/Vector/Growable.hs
+++ b/src/Data/Vector/Growable.hs
@@ -101,7 +101,7 @@ growVectorConserve (GrowVector ref) = do
   (GrowVectorState v size capacity') <- readSTRef ref
   when (size < capacity') $ do
     v' <- MG.unsafeNew size
-    forM_ [0 .. size - 1] $ \i -> MG.read v i >>= MG.write v i
+    forM_ [0 .. size - 1] $ \i -> MG.read v i >>= MG.write v' i
     writeSTRef ref (GrowVectorState v' size size)
 
 growVectorShrink :: MG.MVector v a => GrowVector v s a -> Int -> ST s ()

--- a/src/Data/Vector/Growable.hs
+++ b/src/Data/Vector/Growable.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Data.Vector.Growable
+  ( -- * Growable vectors
+    GrowVector,
+
+    -- ** Type aliases
+    GrowVectorIO,
+    GrowVectorST,
+
+    -- ** Construction
+    new,
+    fromMVector,
+    fromVector,
+
+    -- ** Growing
+    append,
+    reserve,
+
+    -- ** Shrinking
+    conserve,
+    shrink,
+
+    -- ** Information
+    capacity,
+
+    -- ** Manipulation
+    mvector,
+  )
+where
+
+import Control.Monad
+import Control.Monad.Primitive
+import Control.Monad.ST
+import Data.STRef
+import qualified Data.Vector.Generic as G
+import qualified Data.Vector.Generic.Mutable as MG
+import qualified Data.Vector.Growable.Generic as GG
+
+type GrowVectorIO v a = GrowVector v (PrimState IO) a
+
+type GrowVectorST v s a = GrowVector v (PrimState (ST s)) a
+
+-- | A vector that can grow (and shrink).
+--
+-- A `GrowVector` is associated with an `Data.Vector.Generic.Mutable`
+-- instance via an associated type.
+newtype GrowVector v s a = GrowVector
+  { _growVectorState :: STRef s (GrowVectorState v s a)
+  }
+
+data GrowVectorState v s a = GrowVectorState
+  { _growVectorStateVector :: v s a,
+    _growVectorStateSize :: Int,
+    _growVectorStateCapacity :: Int
+  }
+
+instance MG.MVector v a => GG.GrowVector (GrowVector v) a where
+  type MVector (GrowVector v) = v
+
+  basicNew = growVectorNew
+  basicFromMVector = growVectorFromMVector
+  basicAppend = growVectorAppend
+  basicReserve = growVectorReserve
+  basicConserve = growVectorConserve
+  basicShrink = growVectorShrink
+  basicMvector = growVectorMvector
+  basicCapacity = growVectorCapacity
+
+growVectorNew :: MG.MVector v a => Int -> ST s (GrowVector v s a)
+growVectorNew initCapacity = do
+  mv <- MG.unsafeNew initCapacity
+  ref <- newSTRef (GrowVectorState mv 0 initCapacity)
+  pure (GrowVector ref)
+
+growVectorFromMVector :: MG.MVector v a => v s a -> ST s (GrowVector v s a)
+growVectorFromMVector mv =
+  fmap GrowVector (newSTRef (GrowVectorState mv (MG.length mv) (MG.length mv)))
+
+growVectorAppend :: MG.MVector v a => GrowVector v s a -> a -> ST s ()
+growVectorAppend gv@(GrowVector ref) x = do
+  (GrowVectorState _ initSize initCapacity) <- readSTRef ref
+  when (initSize >= initCapacity) (growVectorReserve gv (max 1 initSize * 2))
+  (GrowVectorState v size _) <- readSTRef ref
+  MG.write v size x
+  let capacity'' = MG.length v
+      size' = size + 1
+  writeSTRef ref (GrowVectorState v size' capacity'')
+
+growVectorReserve :: MG.MVector v a => GrowVector v s a -> Int -> ST s ()
+growVectorReserve (GrowVector ref) newCapacity = do
+  (GrowVectorState v size capacity') <- readSTRef ref
+  when (capacity' < newCapacity) $ do
+    v' <- MG.grow v (newCapacity - capacity')
+    writeSTRef ref (GrowVectorState v' size newCapacity)
+
+growVectorConserve :: MG.MVector v a => GrowVector v s a -> ST s ()
+growVectorConserve (GrowVector ref) = do
+  (GrowVectorState v size capacity') <- readSTRef ref
+  when (size < capacity') $ do
+    v' <- MG.unsafeNew size
+    forM_ [0 .. size - 1] $ \i -> MG.read v i >>= MG.write v i
+    writeSTRef ref (GrowVectorState v' size size)
+
+growVectorShrink :: MG.MVector v a => GrowVector v s a -> Int -> ST s ()
+growVectorShrink (GrowVector ref) maxSize = do
+  (GrowVectorState v size capacity') <- readSTRef ref
+  when (size > maxSize) $ do
+    MG.clear (MG.slice maxSize (capacity' - maxSize) v)
+    writeSTRef ref (GrowVectorState v maxSize capacity')
+
+growVectorMvector :: MG.MVector v a => GrowVector v s a -> ST s (v s a)
+growVectorMvector (GrowVector ref) = do
+  (GrowVectorState v size _) <- readSTRef ref
+  pure (MG.slice 0 size v)
+
+growVectorCapacity :: GrowVector v s a -> ST s Int
+growVectorCapacity (GrowVector ref) = do
+  (GrowVectorState _ _ capacity') <- readSTRef ref
+  pure capacity'
+
+-- | Create a new growable vector
+new :: (PrimMonad m, MG.MVector v a) => Int -> m (GrowVector v (PrimState m) a)
+new = GG.new
+
+-- | Create a new growable vector from an immutable vector.
+fromMVector :: (PrimMonad m, MG.MVector v a) => v (PrimState m) a -> m (GrowVector v (PrimState m) a)
+fromMVector = GG.fromMVector
+
+-- | Create a new growable vector from an immutable vector.
+fromVector :: (PrimMonad m, G.Vector v a) => v a -> m (GrowVector (G.Mutable v) (PrimState m) a)
+fromVector = GG.fromVector
+
+-- | Append an element to the vector, growing if necessary.
+--
+-- This takes \(O(1)\) amortized time. If there is sufficient
+-- capacity, this takes \(O(1)\) time; otherwise, this operation takes
+-- \(O(n)\) time.
+append :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> a -> m ()
+append = GG.append
+
+-- | Ensure the capacity of the vector is at least the given size.
+--
+-- If new space must be reserved, this is an \(O(n)\) operation;
+-- otherwise, it is \(O(1)\).
+reserve :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> Int -> m ()
+reserve = GG.reserve
+
+-- | Discard excess capacity.
+--
+-- If there is excess capacity, this is an \(O(n)\) operation;
+-- otherwise, it is \(O(1)\).
+conserve :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> m ()
+conserve = GG.conserve
+
+-- | Shrink the vector to the given size.
+--
+-- This is an \(O(n)\) operation, due to cleaning up discarded
+-- references.
+shrink :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> Int -> m ()
+shrink = GG.shrink
+
+-- | Access the underlying mutable vector.
+--
+-- The vector returned is only valid until a call to `append`,
+-- `reserve`, or `conserve`; after any of these calls, the
+-- `GrowVector` might be pointing to a new `MVector`.
+mvector :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> m (v (PrimState m) a)
+mvector = GG.mvector
+
+-- | The current capacity of the vector.
+--
+-- Up to this many elements may be stored in the vector without
+-- requiring a resize operation.
+capacity :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> m Int
+capacity = GG.capacity

--- a/src/Data/Vector/Growable/Generic.hs
+++ b/src/Data/Vector/Growable/Generic.hs
@@ -53,7 +53,8 @@ class (MG.MVector (MVector v) a) => GrowVector v a where
   basicReserve :: v s a -> Int -> ST s ()
   basicConserve :: v s a -> ST s ()
   basicShrink :: v s a -> Int -> ST s ()
-  basicMvector :: v s a -> ST s (MVector v s a)
+  basicMVector :: v s a -> ST s (MVector v s a)
+  basicLength :: v s a -> ST s Int
   basicCapacity :: v s a -> ST s Int
 
 -- | Create a new growable vector
@@ -106,7 +107,13 @@ shrink v = stToPrim . basicShrink v
 --
 -- Assumed complexity \(O(1)\).
 mvector :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> m (MVector v (PrimState m) a)
-mvector = stToPrim . basicMvector
+mvector = stToPrim . basicMVector
+
+-- | The current length of the vector.
+--
+-- Assumed complexity \(O(1)\).
+length :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> m Int
+length = stToPrim . basicLength
 
 -- | The current capacity of the vector.
 --

--- a/src/Data/Vector/Growable/Generic.hs
+++ b/src/Data/Vector/Growable/Generic.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Data.Vector.Growable.Generic where
+
+import Control.Monad.Primitive
+import Control.Monad.ST
+import Data.Kind
+import qualified Data.Vector.Generic as G
+import qualified Data.Vector.Generic.Mutable as MG
+import qualified Data.Vector.Generic.New as GN
+
+-- | A vector that can grow (and shrink).
+--
+-- Although a `GrowVector` is not a `Data.Vector.Generic.Mutable`
+-- instance, you can get at one via the `mvector` method. The reason
+-- for this indirection is the `Data.Vector.Generic.Mutable.length`
+-- method, which requires the length of the vector to be known purely.
+-- While it would be possible to store the length of a growable vector
+-- in a way so as to satisfy this API, it would make it easy for stale
+-- references to contain garbage length values. In the following
+-- example, imagine we have declared `GrowVector` to implement
+-- `Data.Vector.Mutable.Generic.MVector`.
+--
+-- @
+--     example = do
+--       gv <- fromVector (V.fromList [1..100])
+--       shrink gv 10
+--       print (MV.length gv)
+-- @
+--
+-- What should be printed? Semantically, we want "10" to be printed;
+-- however, since `MV.length gv` cannot invoke side effects, it will
+-- likely print 100 instead. Fixing this would likely require us to
+-- return new references as we go, as in
+--
+-- @
+--     example = do
+--       gv <- fromVector (V.fromList [1..100])
+--       gv' <- shrink gv 10
+--       print (MV.length gv')
+-- @
+--
+-- but this requires a lot of manual bookkeeping, and is still error-prone.
+class (MG.MVector (MVector v) a) => GrowVector v a where
+  type MVector v :: Type -> Type -> Type
+
+  basicNew :: Int -> ST s (v s a)
+  basicFromMVector :: MVector v s a -> ST s (v s a)
+  basicAppend :: v s a -> a -> ST s ()
+  basicReserve :: v s a -> Int -> ST s ()
+  basicConserve :: v s a -> ST s ()
+  basicShrink :: v s a -> Int -> ST s ()
+  basicMvector :: v s a -> ST s (MVector v s a)
+  basicCapacity :: v s a -> ST s Int
+
+-- | Create a new growable vector
+new :: (PrimMonad m, GrowVector v a) => Int -> m (v (PrimState m) a)
+new = stToPrim . basicNew
+
+-- | Create a new growable vector from an existing mutable vector.
+--
+-- The mutable vector should be considered unsafe to use after calling
+-- this; see `fromVector` for a safer alternative.
+--
+-- Assumed complexity \(O(1)\).
+fromMVector :: (PrimMonad m, GrowVector v a) => MVector v (PrimState m) a -> m (v (PrimState m) a)
+fromMVector = stToPrim . basicFromMVector
+
+-- | Create a new growabe vector from an existing vector.
+--
+-- Assumed complexity \(O(n)\).
+fromVector ::
+  (MVector gv ~ G.Mutable v, PrimMonad m, G.Vector v a, GrowVector gv a) =>
+  v a ->
+  m (gv (PrimState m) a)
+fromVector v = GN.runPrim (G.clone v) >>= fromMVector
+
+-- | Append an element to the vector, growing if necessary.
+--
+-- Assumed complexity amortized \(O(1)\).
+append :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> a -> m ()
+append v = stToPrim . basicAppend v
+
+-- | Ensure the capacity of the vector is at least the given size.
+--
+-- Assumed complexity \(O(n)\) when resizing is necessary.
+reserve :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> Int -> m ()
+reserve v = stToPrim . basicReserve v
+
+-- | Discard excess capacity.
+--
+-- Assumed time \(O(n)\) when resizing is necessary.
+conserve :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> m ()
+conserve = stToPrim . basicConserve
+
+shrink :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> Int -> m ()
+shrink v = stToPrim . basicShrink v
+
+-- | Access the underlying mutable vector.
+--
+-- It is likely this value is only safe to use until `append`,
+-- `reserve`, or `conserve` are called.
+--
+-- Assumed complexity \(O(1)\).
+mvector :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> m (MVector v (PrimState m) a)
+mvector = stToPrim . basicMvector
+
+-- | The current capacity of the vector.
+--
+-- Up to this many elements may be stored in the vector without
+-- requiring a resize operation.
+--
+-- Assumed complexity \(O(1)\).
+capacity :: (PrimMonad m, GrowVector v a) => v (PrimState m) a -> m Int
+capacity = stToPrim . basicCapacity

--- a/src/Data/Vector/Growable/MVector.hs
+++ b/src/Data/Vector/Growable/MVector.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Algorithms.GrowVector.MVector
+  ( -- * Growable vectors
+    GrowVector,
+
+    -- ** Type aliases
+    GrowVectorIO,
+    GrowVectorST,
+
+    -- ** Construction
+    new,
+    fromMVector,
+    fromVector,
+
+    -- ** Growing
+    append,
+    reserve,
+
+    -- ** Shrinking
+    conserve,
+    shrink,
+
+    -- ** Information
+    capacity,
+
+    -- ** Manipulation
+    mvector,
+  )
+where
+
+import qualified Algorithms.GrowVector.Generic as GG
+import Control.Monad
+import Control.Monad.Primitive
+import Control.Monad.ST
+import Data.STRef
+import qualified Data.Vector.Generic as G
+import qualified Data.Vector.Generic.Mutable as MG
+
+type GrowVectorIO v a = GrowVector v (PrimState IO) a
+
+type GrowVectorST v s a = GrowVector v (PrimState (ST s)) a
+
+-- | A vector that can grow (and shrink).
+--
+-- A `GrowVector` is associated with an `Data.Vector.Generic.Mutable`
+-- instance via an associated type.
+newtype GrowVector v s a = GrowVector
+  { _growVectorState :: STRef s (GrowVectorState v s a)
+  }
+
+data GrowVectorState v s a = GrowVectorState
+  { _growVectorStateVector :: v s a,
+    _growVectorStateSize :: Int,
+    _growVectorStateCapacity :: Int
+  }
+
+instance (MG.MVector v a) => GG.GrowVector (GrowVector v) a where
+  type MVector (GrowVector v) = v
+
+  basicNew = growVectorNew
+  basicFromMVector = growVectorFromMVector
+  basicAppend = growVectorAppend
+  basicReserve = growVectorReserve
+  basicConserve = growVectorConserve
+  basicShrink = growVectorShrink
+  basicMvector = growVectorMvector
+  basicCapacity = growVectorCapacity
+
+growVectorNew :: (MG.MVector v a) => Int -> ST s (GrowVector v s a)
+growVectorNew initCapacity = do
+  mv <- MG.unsafeNew initCapacity
+  ref <- newSTRef (GrowVectorState mv 0 initCapacity)
+  pure (GrowVector ref)
+
+growVectorFromMVector :: (MG.MVector v a) => v s a -> ST s (GrowVector v s a)
+growVectorFromMVector mv =
+  fmap GrowVector (newSTRef (GrowVectorState mv (MG.length mv) (MG.length mv)))
+
+growVectorAppend :: (MG.MVector v a) => GrowVector v s a -> a -> ST s ()
+growVectorAppend gv@(GrowVector ref) x = do
+  (GrowVectorState _ initSize initCapacity) <- readSTRef ref
+  when (initSize >= initCapacity) (growVectorReserve gv (max 1 initSize * 2))
+  (GrowVectorState v size _) <- readSTRef ref
+  MG.write v size x
+  let capacity'' = MG.length v
+      size' = size + 1
+  writeSTRef ref (GrowVectorState v size' capacity'')
+
+growVectorReserve :: (MG.MVector v a) => GrowVector v s a -> Int -> ST s ()
+growVectorReserve (GrowVector ref) newCapacity = do
+  (GrowVectorState v size capacity') <- readSTRef ref
+  when (capacity' < newCapacity) $ do
+    v' <- MG.grow v (newCapacity - capacity')
+    writeSTRef ref (GrowVectorState v' size newCapacity)
+
+growVectorConserve :: (MG.MVector v a) => GrowVector v s a -> ST s ()
+growVectorConserve (GrowVector ref) = do
+  (GrowVectorState v size capacity') <- readSTRef ref
+  when (size < capacity') $ do
+    v' <- MG.unsafeNew size
+    forM_ [0 .. size - 1] $ \i -> MG.read v i >>= MG.write v i
+    writeSTRef ref (GrowVectorState v' size size)
+
+growVectorShrink :: (MG.MVector v a) => GrowVector v s a -> Int -> ST s ()
+growVectorShrink (GrowVector ref) maxSize = do
+  (GrowVectorState v size capacity') <- readSTRef ref
+  when (size > maxSize) $ do
+    MG.clear (MG.slice maxSize (capacity' - maxSize) v)
+    writeSTRef ref (GrowVectorState v maxSize capacity')
+
+growVectorMvector :: (MG.MVector v a) => GrowVector v s a -> ST s (v s a)
+growVectorMvector (GrowVector ref) = do
+  (GrowVectorState v size _) <- readSTRef ref
+  pure (MG.slice 0 size v)
+
+growVectorCapacity :: GrowVector v s a -> ST s Int
+growVectorCapacity (GrowVector ref) = do
+  (GrowVectorState _ _ capacity') <- readSTRef ref
+  pure capacity'
+
+-- | Create a new growable vector
+new :: (PrimMonad m, MG.MVector v a) => Int -> m (GrowVector v (PrimState m) a)
+new = GG.new
+
+-- | Create a new growable vector from an immutable vector.
+fromMVector :: (PrimMonad m, MG.MVector v a) => v (PrimState m) a -> m (GrowVector v (PrimState m) a)
+fromMVector = GG.fromMVector
+
+-- | Create a new growable vector from an immutable vector.
+fromVector :: (PrimMonad m, G.Vector v a) => v a -> m (GrowVector (G.Mutable v) (PrimState m) a)
+fromVector = GG.fromVector
+
+-- | Append an element to the vector, growing if necessary.
+--
+-- This takes \(O(1)\) amortized time. If there is sufficient
+-- capacity, this takes \(O(1)\) time; otherwise, this operation takes
+-- \(O(n)\) time.
+append :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> a -> m ()
+append = GG.append
+
+-- | Ensure the capacity of the vector is at least the given size.
+--
+-- If new space must be reserved, this is an \(O(n)\) operation;
+-- otherwise, it is \(O(1)\).
+reserve :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> Int -> m ()
+reserve = GG.reserve
+
+-- | Discard excess capacity.
+--
+-- If there is excess capacity, this is an \(O(n)\) operation;
+-- otherwise, it is \(O(1)\).
+conserve :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> m ()
+conserve = GG.conserve
+
+-- | Shrink the vector to the given size.
+--
+-- This is an \(O(n)\) operation, due to cleaning up discarded
+-- references.
+shrink :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> Int -> m ()
+shrink = GG.shrink
+
+-- | Access the underlying mutable vector.
+--
+-- The vector returned is only valid until a call to `append`,
+-- `reserve`, or `conserve`; after any of these calls, the
+-- `GrowVector` might be pointing to a new `MVector`.
+mvector :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> m (v (PrimState m) a)
+mvector = GG.mvector
+
+-- | The current capacity of the vector.
+--
+-- Up to this many elements may be stored in the vector without
+-- requiring a resize operation.
+capacity :: (PrimMonad m, MG.MVector v a) => GrowVector v (PrimState m) a -> m Int
+capacity = GG.capacity

--- a/test/Data/Vector/GrowableSpec.hs
+++ b/test/Data/Vector/GrowableSpec.hs
@@ -1,0 +1,40 @@
+module Data.Vector.GrowableSpec where
+
+import Control.Monad
+import qualified Data.Vector as V
+import qualified Data.Vector.Growable as GV
+import Test.Hspec
+
+spec :: Spec
+spec =
+  describe "GrowVectors" $ do
+    it "can grow" $ do
+      gv <- GV.new 10
+      forM_ [1 .. 100 :: Int] $ \i -> do
+        GV.append gv i
+        v <- GV.mvector gv >>= V.freeze
+        v `shouldBe` V.fromList [1 .. i]
+    it "can grow from an empty vector" $ do
+      gv <- GV.new 0
+      forM_ [1 .. 100 :: Int] $ \i -> do
+        GV.append gv i
+        v <- GV.mvector gv >>= V.freeze
+        v `shouldBe` V.fromList [1 .. i]
+    it "can augment existing MVectors" $ do
+      mv <- V.thaw (V.fromList [1 .. 20 :: Int])
+      gv <- GV.fromMVector mv
+      forM_ [21 .. 100] $ \i -> do
+        GV.append gv i
+        v <- GV.mvector gv >>= V.freeze
+        v `shouldBe` V.fromList [1 .. i]
+    it "can augment existing Vectors" $ do
+      gv <- GV.fromVector (V.fromList [1 .. 20 :: Int])
+      forM_ [21 .. 100] $ \i -> do
+        GV.append gv i
+        v <- GV.mvector gv >>= V.freeze
+        v `shouldBe` V.fromList [1 .. i]
+    it "can be shrunk" $ do
+      gv <- GV.fromVector (V.fromList [1 .. 20 :: Int])
+      GV.shrink gv 10
+      v <- GV.mvector gv >>= V.freeze
+      v `shouldBe` V.fromList [1 .. 10]

--- a/test/Data/Vector/GrowableSpec.hs
+++ b/test/Data/Vector/GrowableSpec.hs
@@ -1,9 +1,16 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Data.Vector.GrowableSpec where
 
 import Control.Monad
+import Control.Monad.Primitive
 import qualified Data.Vector as V
+import qualified Data.Vector.Generic.Mutable as MG
 import qualified Data.Vector.Growable as GV
+import qualified Data.Vector.Growable.Generic as GG
 import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
 
 spec :: Spec
 spec =
@@ -38,3 +45,63 @@ spec =
       GV.shrink gv 10
       v <- GV.mvector gv >>= V.freeze
       v `shouldBe` V.fromList [1 .. 10]
+    prop "behaves correctly" $ \initState actions -> do
+      let expected = evalActionsList initState actions :: [Int]
+      gv <- V.thaw (V.fromList initState) >>= GV.fromMVector
+      evalActions gv actions
+      mv <- GV.mvector gv
+      result <- fmap V.toList (V.freeze mv)
+      result `shouldBe` expected
+
+data GrowCommand = DoAppend | DoReserve | DoConserve | DoShrink | DoCapacity | DoMutate
+  deriving (Show, Enum, Bounded)
+
+instance Arbitrary GrowCommand where
+  arbitrary = arbitraryBoundedEnum
+
+data GrowAction a = Append a | Reserve (NonNegative Int) | Conserve | Shrink (NonNegative Int) | Capacity | Mutate
+  deriving (Show)
+
+newtype GrowActions a = GrowActions [GrowAction a]
+  deriving (Show)
+
+instance (Arbitrary a) => Arbitrary (GrowAction a) where
+  arbitrary =
+    arbitrary >>= \case
+      DoAppend -> fmap Append arbitrary
+      DoReserve -> fmap Reserve arbitrary
+      DoConserve -> pure Conserve
+      DoShrink -> fmap Shrink arbitrary
+      DoCapacity -> pure Capacity
+      DoMutate -> pure Mutate
+
+instance (Arbitrary a) => Arbitrary (GrowActions a) where
+  arbitrary = fmap GrowActions arbitrary
+
+evalActions :: (PrimMonad m, GG.GrowVector v a) => v (PrimState m) a -> [GrowAction a] -> m ()
+evalActions gv = mapM_ eval
+  where
+    eval (Append x) = GG.append gv x
+    eval (Reserve (NonNegative i)) = GG.reserve gv i
+    eval Conserve = GG.conserve gv
+    eval (Shrink (NonNegative i)) = GG.shrink gv i
+    eval Capacity = void (GG.capacity gv)
+    eval Mutate = do
+      mv <- GG.mvector gv
+      let n = MG.length mv
+      when (n > 0) $ do
+        x <- MG.read mv 0
+        forM_ [1 .. n - 1] $ \i -> do
+          MG.read mv i >>= MG.write mv (i - 1)
+        MG.write mv (n - 1) x
+
+evalActionsList :: [a] -> [GrowAction a] -> [a]
+evalActionsList = foldl eval
+  where
+    eval xs (Append x) = xs ++ [x]
+    eval xs (Reserve _) = xs
+    eval xs Conserve = xs
+    eval xs (Shrink (NonNegative i)) = take i xs
+    eval xs Capacity = xs
+    eval [] Mutate = []
+    eval (x : xs) Mutate = xs ++ [x]


### PR DESCRIPTION
## Overview

Add a dynamic vector type that can shrink and grow.

## Details

A `GrowVector` is almost which are almost `MVector`s. The type signature of `length` makes it difficult to use `MVector`s to back a growable vector and still adhere to the `MVector` interface.